### PR TITLE
✨ AddNavigationViews to Preview Providers

### DIFF
--- a/Demo/Shared/Cameras/DocumentCameraScreen.swift
+++ b/Demo/Shared/Cameras/DocumentCameraScreen.swift
@@ -90,7 +90,9 @@ private extension VNDocumentCameraScan {
 struct DocumentCameraScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        DocumentCameraScreen()
+        NavigationView {
+            DocumentCameraScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Cameras/PhotoCameraScreen.swift
+++ b/Demo/Shared/Cameras/PhotoCameraScreen.swift
@@ -78,7 +78,9 @@ private extension PhotoCameraScreen {
 struct PhotoCameraScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        PhotoCameraScreen()
+        NavigationView {
+            PhotoCameraScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Extensions/ExtensionsScreen.swift
+++ b/Demo/Shared/Extensions/ExtensionsScreen.swift
@@ -27,6 +27,8 @@ Since this namespace contains a lot will grow over time, extensions are not demo
 struct ExtensionsScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        ExtensionsScreen()
+        NavigationView {
+            ExtensionsScreen()
+        }
     }
 }

--- a/Demo/Shared/Gestures/GesturesScreen.swift
+++ b/Demo/Shared/Gestures/GesturesScreen.swift
@@ -29,6 +29,8 @@ struct GesturesScreen: View {
 struct GesturesScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        GesturesScreen()
+        NavigationView {
+            GesturesScreen()
+        }
     }
 }

--- a/Demo/Shared/Gestures/SwipeGestureScreen.swift
+++ b/Demo/Shared/Gestures/SwipeGestureScreen.swift
@@ -48,6 +48,8 @@ private extension SwipeGestureScreen {
 struct SwipeGestureScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        SwipeGestureScreen()
+        NavigationView {
+            SwipeGestureScreen()
+        }
     }
 }

--- a/Demo/Shared/Images/ImageRendererScreen.swift
+++ b/Demo/Shared/Images/ImageRendererScreen.swift
@@ -48,6 +48,8 @@ private extension ImageRendererScreen {
 struct ImageRendererScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        ImageRendererScreen()
+        NavigationView {
+            ImageRendererScreen()
+        }
     }
 }

--- a/Demo/Shared/Images/ImagesScreen.swift
+++ b/Demo/Shared/Images/ImagesScreen.swift
@@ -29,6 +29,8 @@ struct ImagesScreen: View {
 struct ImagesScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        ImagesScreen()
+        NavigationView {
+            ImagesScreen()
+        }
     }
 }

--- a/Demo/Shared/Pickers/FilePickerScreen.swift
+++ b/Demo/Shared/Pickers/FilePickerScreen.swift
@@ -72,7 +72,9 @@ private extension FilePickerScreen {
 struct FilePickerScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        FilePickerScreen()
+        NavigationView {
+            FilePickerScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Pickers/ImagePickerScreen.swift
+++ b/Demo/Shared/Pickers/ImagePickerScreen.swift
@@ -90,7 +90,9 @@ private extension ImagePickerScreen {
 struct ImagePickerScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        ImagePickerScreen()
+        NavigationView {
+            ImagePickerScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Pickers/PickersScreen.swift
+++ b/Demo/Shared/Pickers/PickersScreen.swift
@@ -33,7 +33,9 @@ struct PickersScreen: View {
 struct PickersScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        PickersScreen()
+        NavigationView {
+            PickersScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Presentation/AlertsScreen.swift
+++ b/Demo/Shared/Presentation/AlertsScreen.swift
@@ -42,6 +42,8 @@ private extension AlertsScreen {
 struct AlertsScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        AlertsScreen()
+        NavigationView {
+            AlertsScreen()
+        }
     }
 }

--- a/Demo/Shared/Presentation/CoversScreen.swift
+++ b/Demo/Shared/Presentation/CoversScreen.swift
@@ -79,7 +79,9 @@ private extension CoversScreen {
 struct CoversScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        CoversScreen()
+        NavigationView {
+            CoversScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Presentation/SheetsScreen.swift
+++ b/Demo/Shared/Presentation/SheetsScreen.swift
@@ -91,6 +91,8 @@ private extension View {
 struct SheetsScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        SheetsScreen()
+        NavigationView {
+            SheetsScreen()
+        }
     }
 }

--- a/Demo/Shared/Sharing/ShareSheetScreen.swift
+++ b/Demo/Shared/Sharing/ShareSheetScreen.swift
@@ -53,7 +53,9 @@ private extension ShareSheetScreen {
 struct ShareSheetScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        ShareSheetScreen()
+        NavigationView {
+            ShareSheetScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Sharing/SharingScreen.swift
+++ b/Demo/Shared/Sharing/SharingScreen.swift
@@ -30,7 +30,9 @@ struct SharingScreen: View {
 struct SharingScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        SharingScreen()
+        NavigationView {
+            SharingScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Styles/CornerRadiusStyleScreen.swift
+++ b/Demo/Shared/Styles/CornerRadiusStyleScreen.swift
@@ -64,6 +64,8 @@ private enum DemoStyle: String {
 struct CornerRadiusStyleScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        CornerRadiusStyleScreen()
+        NavigationView {
+            CornerRadiusStyleScreen()
+        }
     }
 }

--- a/Demo/Shared/Styles/FontStyleScreen.swift
+++ b/Demo/Shared/Styles/FontStyleScreen.swift
@@ -68,7 +68,9 @@ private enum DemoStyle: String {
 struct FontStyleScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        FontStyleScreen()
+        NavigationView {
+            FontStyleScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Styles/StylesScreen.swift
+++ b/Demo/Shared/Styles/StylesScreen.swift
@@ -37,6 +37,8 @@ SwiftUIKit has styles that make it easier to define and apply custom styles.
 struct StylesScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        StylesScreen()
+        NavigationView {
+            StylesScreen()
+        }
     }
 }

--- a/Demo/Shared/Styles/ViewShadowStyleScreen.swift
+++ b/Demo/Shared/Styles/ViewShadowStyleScreen.swift
@@ -65,6 +65,8 @@ private enum DemoStyle: String {
 struct ShadowStyleScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        ViewShadowStyleScreen()
+        NavigationView {
+            ViewShadowStyleScreen()
+        }
     }
 }

--- a/Demo/Shared/Views/CircularProgressBarScreen.swift
+++ b/Demo/Shared/Views/CircularProgressBarScreen.swift
@@ -57,6 +57,8 @@ private extension CircularProgressBarScreen {
 struct CircularProgressBarScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        CircularProgressBarScreen()
+        NavigationView {
+            CircularProgressBarScreen()
+        }
     }
 }

--- a/Demo/Shared/Views/DismissableViewScreen.swift
+++ b/Demo/Shared/Views/DismissableViewScreen.swift
@@ -31,6 +31,8 @@ struct DismissableViewScreen: View, DismissableView {
 struct DismissableViewScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        DismissableViewScreen()
+        NavigationView {
+            DismissableViewScreen()
+        }
     }
 }

--- a/Demo/Shared/Views/FetchedDataViewScreen.swift
+++ b/Demo/Shared/Views/FetchedDataViewScreen.swift
@@ -54,6 +54,8 @@ private extension FetchedDataViewScreen {
 struct FetchedDataViewScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        FetchedDataViewScreen()
+        NavigationView {
+            FetchedDataViewScreen()
+        }
     }
 }

--- a/Demo/Shared/Views/FlipViewScreen.swift
+++ b/Demo/Shared/Views/FlipViewScreen.swift
@@ -48,7 +48,9 @@ private extension FlipViewScreen {
 struct FlipScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        FlipViewScreen()
+        NavigationView {
+            FlipViewScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Views/MultilineTextFieldScreen.swift
+++ b/Demo/Shared/Views/MultilineTextFieldScreen.swift
@@ -32,7 +32,9 @@ struct MultilineTextFieldScreen: View {
 struct MultilineTextFieldScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        MultilineTextFieldScreen()
+        NavigationView {
+            MultilineTextFieldScreen()
+        }
     }
 }
 #endif

--- a/Demo/Shared/Views/PageViewScreen.swift
+++ b/Demo/Shared/Views/PageViewScreen.swift
@@ -44,7 +44,9 @@ private extension PageViewScreen {
 struct PageViewScreen_Previews: PreviewProvider {
     
     static var previews: some View {
-        PageViewScreen()
+        NavigationView {
+            PageViewScreen()
+        }
     }
 }
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,9 @@ import PackageDescription
 let package = Package(
     name: "SwiftUIKit",
     platforms: [
-        .iOS(.v13),
-        .tvOS(.v13),
-        .watchOS(.v6),
+        .iOS(.v14),
+        .tvOS(.v14),
+        .watchOS(.v7),
         .macOS(.v11)
     ],
     products: [

--- a/Sources/SwiftUIKit/Scrolling/ScrollViewHeader.swift
+++ b/Sources/SwiftUIKit/Scrolling/ScrollViewHeader.swift
@@ -103,6 +103,37 @@ public extension ScrollViewHeader {
 @available(iOS 16.0, *)
 struct ScrollViewHeader_Previews: PreviewProvider {
 
+    struct PreviewHeader: View {
+
+        let scrollOffset: CGPoint
+        let visibleRatio: CGFloat
+
+        var body: some View {
+            ZStack(alignment: .bottomLeading) {
+                LinearGradient(
+                    colors: [.red, .blue],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing)
+                LinearGradient(
+                    colors: [.clear, .black.opacity(0.6)],
+                    startPoint: .top,
+                    endPoint: .bottom)
+                headerTitle
+            }.colorScheme(.dark)
+        }
+
+        private var headerTitle: some View {
+            VStack(alignment: .leading) {
+                Text("Title").font(.title)
+                Text("Subtitle").font(.headline)
+            }
+            .opacity(visibleRatio)
+            .shadow(.elevated)
+            .padding()
+        }
+    }
+
+
     struct Preview: View {
 
         @State
@@ -119,89 +150,56 @@ struct ScrollViewHeader_Previews: PreviewProvider {
 
         var body: some View {
             NavigationView {
-                NavigationLink("FOOOO") {
-                    ZStack(alignment: .top) {
-                        GeometryReader { proxy in
-                            ScrollViewWithOffset(scrollOffset: $scrollOffset) {
-                                VStack {
-                                    scrollHeader
-
-                                    Text("\(scrollHeaderVisibleRatio)")
-                                    Text("\(scrollOffset.y)")
-                                    Text("\(scrollHeaderHeight)")
-                                    Text("\(scrollHeaderHeight + scrollOffset.y)")
-
-                                    ForEach(1...100, id: \.self) {
-                                        Text("\($0)").frame(maxWidth: .infinity)
-                                    }.background(Color.primary.colorInvert())
-                                }
-                            }
-                            .toolbar {
-                                ToolbarItem(placement: .navigationBarTrailing) {
-                                    Button("Edit") {}
-                                }
-                            }
-                            .onAppear {
-                                DispatchQueue.main.async {
-                                    navigationBarHeight = proxy.safeAreaInsets.top
-                                }
-                            }
+                ScrollViewWithStickyHeader(
+                    scrollOffset: $scrollOffset,
+                    header: header,
+                    headerHeight: scrollHeaderHeight
+                ) {
+                    VStack {
+                        ForEach(1...100, id: \.self) {
+                            Text("\($0)").frame(maxWidth: .infinity)
+                            Divider()
                         }
-
-                        navbarOverlay
-                            .ignoresSafeArea(edges: .top)
-                    }
-                    .navigationBarTitleDisplayMode(.inline)
-                    .navigationBarTitle("Title")
-                    .toolbar {
-                        ToolbarItem(placement: .principal) {
-                            Text("Title")
-                                .font(.callout.bold())
-                                .opacity(1-scrollHeaderVisibleRatio)
-                                .environment(\.colorScheme, .dark)
-                        }
-                    }
-                    .toolbarBackground(.hidden, for: .navigationBar)
-                }.accentColor(.accentColor)
+                    }.padding()
+                }
+                .setupPreview(with: scrollHeaderVisibleRatio)
             }
             .accentColor(.white)
         }
 
-        private var scrollHeader: some View {
-            ScrollViewHeader(parallaxMode: .none) {
-                ZStack(alignment: .bottomLeading) {
-                    LinearGradient(
-                        colors: [.red, .blue],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing)
-                    LinearGradient(
-                        colors: [.clear, .black.opacity(0.6)],
-                        startPoint: .top,
-                        endPoint: .bottom)
-                    VStack(alignment: .leading) {
-                        Text("Title").font(.title)
-                        Text("Subtitle").font(.headline)
-                    }
-                    .opacity(scrollHeaderVisibleRatio)
-                    .shadow(.elevated)
-                    .padding()
-                }.colorScheme(.dark)
-            }.frame(height: scrollHeaderHeight)
-        }
-
-        @ViewBuilder
-        private var navbarOverlay: some View {
-            if (scrollHeaderVisibleRatio <= 0) {
-                Color.clear
-                    .frame(height: navigationBarHeight)
-                    .overlay(scrollHeader, alignment: .bottom)
-            } else {
-                Color.clear
-            }
+        private func header() -> PreviewHeader {
+            PreviewHeader(
+                scrollOffset: scrollOffset,
+                visibleRatio: scrollHeaderVisibleRatio
+            )
         }
     }
 
     static var previews: some View {
         Preview()
+    }
+}
+
+@available(iOS 16.0, *)
+private extension View {
+
+    func setupPreview(with headerVisibleRatio: CGFloat) -> some View {
+        self
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitle("Title")
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text("Title")
+                        .font(.callout.bold())
+                        .opacity(1-headerVisibleRatio)
+                        .environment(\.colorScheme, .dark)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Edit") {}
+                }
+            }
+            .toolbarBackground(.hidden, for: .navigationBar)
     }
 }

--- a/Sources/SwiftUIKit/Scrolling/ScrollViewWithOffset.swift
+++ b/Sources/SwiftUIKit/Scrolling/ScrollViewWithOffset.swift
@@ -72,7 +72,6 @@ private struct ScrollOffsetPreferenceKey: PreferenceKey {
     static func reduce(value: inout CGPoint, nextValue: () -> CGPoint) {}
 }
 
-@available(iOS 14.0, *)
 struct ScrollViewWithOffset_Previews: PreviewProvider {
 
     struct Preview: View {

--- a/Sources/SwiftUIKit/Scrolling/ScrollViewWithOffset.swift
+++ b/Sources/SwiftUIKit/Scrolling/ScrollViewWithOffset.swift
@@ -1,0 +1,100 @@
+//
+//  ScrollViewWithOffset.swift
+//  SwiftUIKit
+//
+//  Created by Daniel Saidi on 2023-02-03.
+//  Copyright © 2023 Daniel Saidi. All rights reserved.
+//
+
+import SwiftUI
+
+/**
+ This scroll view wraps a native `ScrollView` and tracks its
+ scroll offset as it scrolls.
+ */
+public struct ScrollViewWithOffset<Content: View>: View {
+
+    /**
+     Create a scroll view with offset tracking.
+
+     - Parameters:
+       - axes: The scroll axes to use.
+       - scrollOffset: A scroll offset binding.
+       - showsIndicators: Whether or not to show scroll indicators.
+       - content: The scroll view content.
+     */
+    public init(
+        _ axes: Axis.Set = .vertical,
+        scrollOffset: Binding<CGPoint>,
+        showsIndicators: Bool = true,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.axes = axes
+        self.scrollOffset = scrollOffset
+        self.showsIndicators = showsIndicators
+        self.content = content
+    }
+
+    let axes: Axis.Set
+    let scrollOffset: Binding<CGPoint>
+    let showsIndicators: Bool
+    let content: () -> Content
+
+    public var body: some View {
+        ScrollView(axes, showsIndicators: showsIndicators) {
+            ZStack(alignment: .top) {
+                GeometryReader { geo in
+                    Color.clear
+                        .preference(
+                            key: ScrollOffsetPreferenceKey.self,
+                            value: geo.frame(in: .named(ScrollOffsetNamespace.namespace)).origin
+                        )
+                }
+                .frame(height: 0)
+
+                content()
+            }
+        }
+        .coordinateSpace(name: ScrollOffsetNamespace.namespace)
+        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { scrollOffset.wrappedValue = $0 }
+    }
+}
+
+private enum ScrollOffsetNamespace {
+
+    static let namespace = "scrollView"
+}
+
+private struct ScrollOffsetPreferenceKey: PreferenceKey {
+
+    static var defaultValue: CGPoint = .zero
+
+    static func reduce(value: inout CGPoint, nextValue: () -> CGPoint) {}
+}
+
+@available(iOS 14.0, *)
+struct ScrollViewWithOffset_Previews: PreviewProvider {
+
+    struct Preview: View {
+
+        @State
+        private var scrollOffset: CGPoint = .zero
+
+        var body: some View {
+            NavigationView {
+                ScrollViewWithOffset(scrollOffset: $scrollOffset) {
+                    LazyVStack {
+                        ForEach(1...100, id: \.self) {
+                            Divider()
+                            Text("\($0)").frame(maxWidth: .infinity)
+                        }
+                    }
+                }.navigationTitle("Offset: \(scrollOffset.y)")
+            }
+        }
+    }
+
+    static var previews: some View {
+        Preview()
+    }
+}

--- a/Sources/SwiftUIKit/Scrolling/ScrollViewWithStickyHeader.swift
+++ b/Sources/SwiftUIKit/Scrolling/ScrollViewWithStickyHeader.swift
@@ -1,0 +1,166 @@
+//
+//  ScrollViewWithStickyHeader.swift
+//  SwiftUIKit
+//
+//  Created by Daniel Saidi on 2023-02-03.
+//  Copyright © 2023 Daniel Saidi. All rights reserved.
+//
+
+import SwiftUI
+
+/**
+ This scroll view lets you provide a custom header view that
+ sticks to the top as the scroll view scrolls.
+
+ The view wraps a ``ScrollViewWithOffset`` view and uses the
+ provided scroll offset information to determine how much of
+ the header that should be visible.
+
+ Note that the view will enforce an `inline` navigation view
+ title display mode, since the large header isn't applicable.
+ You can however use the `scollOffset` with a custom toolbar
+ title view to fade in the title as the view scrolls. Please
+ have a look at the preview for an example.
+ */
+public struct ScrollViewWithStickyHeader<Header: View, Content: View>: View {
+
+    /**
+     Create a scroll view with a sticky header.
+
+     - Parameters:
+       - axes: The scroll axes to use.
+       - scrollOffset: A scroll offset binding.
+       - showsIndicators: Whether or not to show scroll indicators.
+       - header: The sticky header view builder.
+       - headerHeight: The height to apply to the header view.
+       - content: The scroll view content builder.
+     */
+    public init(
+        _ axes: Axis.Set = .vertical,
+        scrollOffset: Binding<CGPoint>,
+        showsIndicators: Bool = true,
+        @ViewBuilder header: @escaping () -> Header,
+        headerHeight: CGFloat,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.axes = axes
+        self.scrollOffset = scrollOffset
+        self.showsIndicators = showsIndicators
+        self.header = header
+        self.headerHeight = headerHeight
+        self.content = content
+    }
+
+    let axes: Axis.Set
+    let scrollOffset: Binding<CGPoint>
+    let showsIndicators: Bool
+    let header: () -> Header
+    let headerHeight: CGFloat
+    let content: () -> Content
+
+    @State
+    private var navigationBarHeight: CGFloat = 0
+
+    private var headerVisibleRatio: CGFloat {
+        (headerHeight + scrollOffset.wrappedValue.y) / headerHeight
+    }
+
+    public var body: some View {
+        ZStack(alignment: .top) {
+            scrollView
+            navbarOverlay
+                .ignoresSafeArea(edges: .top)
+        }
+        .prefersTransparentNavigationBar()
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private extension ScrollViewWithStickyHeader {
+
+    var headerView: some View {
+        header().frame(height: headerHeight)
+    }
+
+    @ViewBuilder
+    var navbarOverlay: some View {
+        if (headerVisibleRatio <= 0) {
+            Color.clear
+                .frame(height: navigationBarHeight)
+                .overlay(scrollHeader, alignment: .bottom)
+        } else {
+            Color.clear
+        }
+    }
+
+    var scrollView: some View {
+        GeometryReader { proxy in
+            ScrollViewWithOffset(scrollOffset: scrollOffset) {
+                VStack(spacing: 0) {
+                    scrollHeader
+                    content()
+                }
+            }
+            .onAppear {
+                DispatchQueue.main.async {
+                    navigationBarHeight = proxy.safeAreaInsets.top
+                }
+            }
+        }
+    }
+
+    var scrollHeader: some View {
+        ScrollViewHeader(parallaxMode: .none) {
+            header()
+        }.frame(height: headerHeight)
+    }
+}
+
+struct ScrollViewWithStickyHeader_Previews: PreviewProvider {
+
+    struct Preview: View {
+
+        @State
+        private var scrollOffset: CGPoint = .zero
+
+        let headerHeight: CGFloat = 300
+
+        var headerVisibleRatio: CGFloat {
+            (headerHeight + scrollOffset.y) / headerHeight
+        }
+
+        var body: some View {
+            NavigationView {
+                ScrollViewWithStickyHeader(
+                    scrollOffset: $scrollOffset,
+                    header: { LinearGradient(colors: [.blue, .yellow], startPoint: .top, endPoint: .bottom) },
+                    headerHeight: 250
+                ) {
+                    VStack {
+                        ForEach(1...100, id: \.self) {
+                            Text("\($0)").frame(maxWidth: .infinity)
+                            Divider()
+                        }
+                    }.padding()
+                }
+                .navigationTitle("\(scrollOffset.y) | \(headerVisibleRatio)")
+            }
+        }
+    }
+
+    static var previews: some View {
+        Preview()
+    }
+}
+
+private extension View {
+
+    @ViewBuilder
+    func prefersTransparentNavigationBar() -> some View {
+        if #available(iOS 16.0, *) {
+            self.toolbarBackground(.hidden, for: .navigationBar)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/SwiftUIKit/SwiftUIKit.docc/SwiftUIKit.md
+++ b/Sources/SwiftUIKit/SwiftUIKit.docc/SwiftUIKit.md
@@ -144,6 +144,10 @@ SwiftUIKit is available under the MIT license.
 - ``PrintableItem``
 - ``StandardItemPrinter``
 
+### Scrolling
+
+- ``ScrollViewWithOffset``
+
 ### Sharing
 
 - ``ShareSheet``

--- a/Sources/SwiftUIKit/SwiftUIKit.docc/SwiftUIKit.md
+++ b/Sources/SwiftUIKit/SwiftUIKit.docc/SwiftUIKit.md
@@ -146,6 +146,7 @@ SwiftUIKit is available under the MIT license.
 
 ### Scrolling
 
+- ``ScrollViewHeader``
 - ``ScrollViewWithOffset``
 
 ### Sharing
@@ -174,7 +175,6 @@ SwiftUIKit is available under the MIT license.
 - ``PageIndicatorStyle``
 - ``PageView``
 - ``SearchBar``
-- ``ScrollViewHeader``
 - ``TextReplacement``
 
 ### Views/CollectionView

--- a/Sources/SwiftUIKit/SwiftUIKit.docc/SwiftUIKit.md
+++ b/Sources/SwiftUIKit/SwiftUIKit.docc/SwiftUIKit.md
@@ -148,6 +148,7 @@ SwiftUIKit is available under the MIT license.
 
 - ``ScrollViewHeader``
 - ``ScrollViewWithOffset``
+- ``ScrollViewWithStickyHeader``
 
 ### Sharing
 


### PR DESCRIPTION
### Background

A bunch of PreviewProviders within the Demo App did not have NavigationView in the previews and therefore the NavigationLinks inside the Screens didn't work.

### Solution

I have added NavigationViews to almost all the Previews where needed.